### PR TITLE
Update project/repository URLs, bump version 0.1.2

### DIFF
--- a/src/lib/functions.tmdl
+++ b/src/lib/functions.tmdl
@@ -21,7 +21,7 @@ function 'DaxLib.Filtering.FirstDateWithTransactions' = ```
     RETURN TREATAS ( { FirstDateWithData }, dateColumn )
     ```
     annotation DAXLIB_PackageId = DaxLib.Filtering
-    annotation DAXLIB_PackageVersion = 0.1.1-beta
+    annotation DAXLIB_PackageVersion = 0.1.2
 
 /// Return the value of the expression evaluated in the first date where there are transactions
 /// @param {expr} valueExpr - Expression to evaluate in the first transaction by dateTransaction
@@ -45,7 +45,7 @@ function 'DaxLib.Filtering.FirstValue' = ```
     )
     ```
     annotation DAXLIB_PackageId = DaxLib.Filtering
-    annotation DAXLIB_PackageVersion = 0.1.1-beta
+    annotation DAXLIB_PackageVersion = 0.1.2
 
 /// Retrieve the last date in dateColumnn where there is a transaction in dateTransaction
 /// it can replace FIRSTNONBLANKVALUE when we can assume that the expression is not blank 
@@ -70,7 +70,7 @@ function 'DaxLib.Filtering.LastDateWithTransactions' = ```
     RETURN TREATAS ( { LastDateWithData }, dateColumn )
     ```
     annotation DAXLIB_PackageId = DaxLib.Filtering
-    annotation DAXLIB_PackageVersion = 0.1.1-beta
+    annotation DAXLIB_PackageVersion = 0.1.2
     
 /// Return the value of the expression evaluated in the last date where there are transactions
 /// @param {expr} valueExpr - Expression to evaluate in the last transaction by dateTransaction
@@ -94,7 +94,7 @@ function 'DaxLib.Filtering.LastValue' = ```
     )
     ```
     annotation DAXLIB_PackageId = DaxLib.Filtering
-    annotation DAXLIB_PackageVersion = 0.1.1-beta
+    annotation DAXLIB_PackageVersion = 0.1.2
 
 
 /// Search a value in a lookupDate that has min/max columns and a target column containing the value to return
@@ -130,4 +130,4 @@ function 'DaxLib.Filtering.RangeLookup' = ```
         )
         ```
     annotation DAXLIB_PackageId = DaxLib.Filtering
-    annotation DAXLIB_PackageVersion = 0.1.1-beta
+    annotation DAXLIB_PackageVersion = 0.1.2

--- a/src/manifest.daxlib
+++ b/src/manifest.daxlib
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/daxlib/daxlib/refs/heads/main/schemas/manifest/1.0.0/manifest.1.0.0.schema.json",
   "id": "DaxLib.Filtering",
-  "version": "0.1.1-beta",
+  "version": "0.1.2",
   "authors": "DAXLIB",
   "description": "A comprehensive set of User-Defined Functions designed to apply and manipulate filter, and to search values.",
   "tags": "DAX,UDF,FUNCTION,LIB,FILTER",

--- a/src/manifest.daxlib
+++ b/src/manifest.daxlib
@@ -2,8 +2,11 @@
   "$schema": "https://raw.githubusercontent.com/daxlib/daxlib/refs/heads/main/schemas/manifest/1.0.0/manifest.1.0.0.schema.json",
   "id": "DaxLib.Filtering",
   "version": "0.1.1-beta",
-  "authors": "DAXLIB,SQLBI",
+  "authors": "DAXLIB",
   "description": "A comprehensive set of User-Defined Functions designed to apply and manipulate filter, and to search values.",
   "tags": "DAX,UDF,FUNCTION,LIB,FILTER",
+  "releaseNotes": "Update metadata with new project and repository URLs",
+  "projectUrl": "https://github.com/daxlib/dev-daxlib-filtering",
+  "repositoryUrl": "https://github.com/daxlib/dev-daxlib-filtering",
   "icon": "/icon.png"
 }


### PR DESCRIPTION
This pull request updates the package metadata and version for the `DaxLib.Filtering` library. The main focus is on incrementing the version to `0.1.2` and refreshing the manifest to include new project/repository URLs.

Version and metadata updates:

* Incremented the package version from `0.1.1-beta` to `0.1.2` in all function annotations within `src/lib/functions.tmdl` and in the manifest file.
* Updated the manifest file `src/manifest.daxlib` to add release notes, and specify new `projectUrl` and `repositoryUrl` values.